### PR TITLE
Remove sample configuration values unused by 'Services'

### DIFF
--- a/docs/package-apis.md
+++ b/docs/package-apis.md
@@ -57,12 +57,13 @@ By default, the config function will be called with an object containing the fol
 | services        | Object     | An instantiated `Services` class. It contains methods related to loading and starting API services. |
 | app             | Object     | An instantiated Express router used by the `Services` class. |
 
-The instantiated `services` contains the following public methods:
+The instantiated `services` contains the following public properties:
 | Name              | Type      | Description                                                       |
 |:----------------- |:---------:| :-----------------------------------------------------------------|
 | isSiteActive        | Function                | Returns true after `services.expressStatic` is called. |
 | start                 | Function | Starts all the API routes and Socket connections. |
 | io                  | Function | Returns an instantiated instance of `Socket.IO` |
+| app                 | Object   | The instantiated Express app |
 
 ##Socket.io APIs
 

--- a/docs/run-package.md
+++ b/docs/run-package.md
@@ -1,15 +1,5 @@
 ###Activating REST/Socket API services
 
-By default, no API services will be loaded. Set `LoadServices` to true in your local config.json file to enable them.
-
-Example:
-```json
-// config.json
-"services" : {
-   "LoadServices": true
- }
-```
-
 Run `lsc start services` in the root of the package directory. The API routes of the package should now be available for use 
 (e.g. `http://localhost:8000/<ServicePath>/<Package-Name>/<Api-Route>`).
 

--- a/lib/api/socket-io-loader.js
+++ b/lib/api/socket-io-loader.js
@@ -3,7 +3,6 @@
 const io = require('socket.io'),
     clientio = require('socket.io-client'),
     path = require('path'),
-    util = require('util'),
     assert = require('assert'),
     {EventEmitter} = require('events'),
     _ = require('lodash'),
@@ -29,30 +28,23 @@ class SocketIOLoader extends EventEmitter {
     // the `onConnect` functions when the socket connections are asynchronously established
 
     /**
-     *
-     * @param {object} server - An instance of an HTTP server (Note: an Express.js request handler is not valid)
      * @param {object} options
      * @param {string} options.main - The path to a LabShare package
      * @param {string|Array} options.directories - Additional directories to check for socket.io modules
      * @param {string} options.pattern - The glob pattern to use when searching for socket.io modules
      * @constructor
      */
-    constructor(server, options={}) {
-        assert.ok(_.isObject(server), 'SocketIOLoader: `server` must be a valid HTTP server instance');
-
+    constructor(options = {}) {
         super();
 
-        this.io = io(server);
-        this.io.sockets.setMaxListeners(50);  // Increase Node's default limit of 10 listeners
-
         if (options.main) {
-            assert.ok(_.isString(options.main), '`options.main` must be a string');
+            assert.ok(_.isString(options.main), 'SocketIOLoader: `options.main` must be a string');
             options.main = path.resolve(options.main);
         }
         if (options.directories) {
             options.directories = apiUtils.wrapInArray(options.directories);
-            options.directories = _.map(options.directories, (directory) => {
-                assert.ok(_.isString(directory), '`options.directories` must contain non-empty strings');
+            options.directories = _.map(options.directories, directory => {
+                assert.ok(_.isString(directory), 'SocketIOLoader: `options.directories` must contain non-empty strings');
                 return path.resolve(directory);
             });
         }
@@ -67,11 +59,17 @@ class SocketIOLoader extends EventEmitter {
 
     /**
      * @description Set up all the package Socket.io connections
+     * @param {object} server - An instance of an HTTP server (Note: an Express.js request handler is not valid)
      * @api
      */
-    connect() {
+    connect(server) {
+        assert.ok(_.isObject(server), 'SocketIOLoader: `server` is required');
+
+        this.io = io(server);
+        this.io.sockets.setMaxListeners(50);  // Increase Node's default limit of 10 listeners
+
         // Establish client connections for Node process P2P communication
-        _.each(this.options.connections, (connection) => {
+        _.each(this.options.connections, connection => {
             const clientSocket = clientio.connect(connection);
             this._establishSocketConnections(this._connectPackage, clientSocket);
             clientSocket.once('connect', () => {
@@ -99,6 +97,9 @@ class SocketIOLoader extends EventEmitter {
      * @returns The initialized Socket.IO instance
      */
     getIO() {
+        if (!this.io) {
+            throw new Error('SocketIOLoader: `.connect()` must be called with a valid HTTP server first!');
+        }
         return this.io;
     }
 
@@ -174,7 +175,7 @@ class SocketIOLoader extends EventEmitter {
             }
 
             if (!_.isFunction(connectHandler)) {
-                this.emit('error', new Error(util.format('The `onConnect` property exposed by module "%s" must be a function!', modulePath)));
+                this.emit('error', new Error(`The "onConnect" property exposed by module "${modulePath}" must be a function!`));
             } else {
                 connectHandler(socket);
             }

--- a/lib/server-utils.js
+++ b/lib/server-utils.js
@@ -22,10 +22,6 @@ function shutdown(server, timeout) {
     }
 }
 
-exports.isServicesEnabled = function () {
-    return _.get(global.LabShare, 'Config.services.LoadServices');
-};
-
 exports.isDevMode = function () {
     return !process.env.NODE_ENV || process.env.NODE_ENV === 'development';
 };

--- a/lib/services.js
+++ b/lib/services.js
@@ -19,26 +19,28 @@ class Services {
 
     /**
      * @description Adds authentication and service middleware to the given Express app
-     * @param {Object} options
+     * @param {Object} [options]
      * @param {Boolean} [options.auth] - Enable route authentication. Defaults to true.
      * @param {Object} [options.data] - Config data or other metadata to pass to the 'Config' functions executed by the ApiLoader.
      * Default: { services: Service(), apiLoader, express }
+     * @param {Boolean} [options.loadServices] - Do not load APIs if false. Default: true
      */
     constructor(options = {}) {
-        this.express = express;
-        this.app = this.express();
-        this.siteActive = false;
-        this.options = _.defaults(options, {
+        this.app = express();
+        this._options = _.defaults(options, {
             auth: true,
             logger: console,
             main: process.cwd(),
             directories: [],
             pattern: '{src/api,api}/*.js',
             connections: _.get(global.LabShare, 'Config.services.Socket.Connections'),
-            data: {}
+            data: {},
+            loadServices: true
         });
-        this.apiLoader = new Loader(this.app, this.options);
-        this.socketLoader = null;
+        this._express = express;
+        this._siteActive = false;
+        this._apiLoader = new Loader(this.app, this._options);
+        this._socketLoader = new SocketIOLoader(this._options);
     }
 
     start() {
@@ -49,7 +51,7 @@ class Services {
         this.app.use(cors());
         this.app.use(morgan(requestLoggingMode));
 
-        if (this.options.auth) {
+        if (this._options.auth) {
             this.app.use(restrict);  // Add API route authentication
         } else {
             // Add a fake user for integration testing purposes
@@ -59,52 +61,49 @@ class Services {
             });
         }
 
-        this.apiLoader.initialize();
+        this._apiLoader.initialize();
 
         // Run all the package API 'config' functions
-        this.apiLoader.setConfig(_.extend(this.options.data, {
+        this._apiLoader.setConfig(_.extend(this._options.data, {
             services: this,
-            apiLoader: this.apiLoader,
-            express: this.express,
+            apiLoader: this._apiLoader,
+            express: this._express,
             app: this.app
         }));
 
-        let server = serverUtils.startServer(this.app, this.options.logger);
-
-        this.socketLoader = new SocketIOLoader(server, this.options);
+        let server = serverUtils.startServer(this.app, this._options.logger);
 
         // add API routes and socket connections unless configured not to
-        if (serverUtils.isServicesEnabled()) {
-            this.apiLoader.setAPIs(_.get(global.LabShare, 'Config.services.ServicePath') || '/');
+        if (this._options.loadServices) {
+            this._apiLoader.setAPIs(_.get(global.LabShare, 'Config.services.ServicePath') || '/');
 
-            this.socketLoader = new SocketIOLoader(server, this.options);
-            this.socketLoader.connect();
-            this.socketLoader.on('error', error => {
-                this.options.logger.error(error);
+            this._socketLoader.connect(server);
+            this._socketLoader.on('error', error => {
+                this._options.logger.error(error);
             });
-            this.socketLoader.on('status', message => {
-                this.options.logger.info(message);
+            this._socketLoader.on('status', message => {
+                this._options.logger.info(message);
             });
 
             // TODO: perform this global assignment OUTSIDE of the Services class
 
             global.LabShare.IO = this.io();
         } else {
-            this.options.logger.warn('API services are disabled because the LabShare Service\'s configuration value for `LoadServices` is missing or set to false!');
+            this._options.logger.warn('API services are disabled because Service\'s `options.loadServices` is missing or set to false!');
         }
     }
 
     expressStatic({mountPoint, root, options}) {
-        this.siteActive = true;
-        this.app.use(mountPoint, this.express.static(root, options));
+        this._siteActive = true;
+        this.app.use(mountPoint, this._express.static(root, options));
     }
 
     isSiteActive() {
-        return this.siteActive;
+        return this._siteActive;
     }
 
     io() {
-        return this.socketLoader.getIO();
+        return this._socketLoader.getIO();
     }
 }
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "services",
   "namespace": "",
   "main": "./",
-  "version": "v0.16.607",
+  "version": "v0.16.608",
   "description": "LabShare API service manager",
   "private": true,
   "contributors": "https://github.com/LabShare/services/graphs/contributors",

--- a/sample-config.json
+++ b/sample-config.json
@@ -7,16 +7,6 @@
     "Socket": {
       "Connections": []
     },
-    "Auth": {
-      "Providers": [
-        "google",
-        "azure",
-        "nih/wsfed"
-      ],
-      "Url": "https://a.labshare.org"
-    },
-    "ServiceUrl": "",
-    "ServicePath": "",
-    "LoadServices": false
+    "ServicePath": ""
   }
 }

--- a/test/lib/unit/api/socket-io-loader_spec.js
+++ b/test/lib/unit/api/socket-io-loader_spec.js
@@ -1,13 +1,15 @@
-var path = require('path'),
+'use strict';
+
+const path = require('path'),
     proxyquire = require('proxyquire'),
     express = require('express'),
-    EventEmitter = require('events').EventEmitter;
+    {EventEmitter} = require('events');
 
 require('promise-matchers');
 
 describe('SocketIOLoader', function () {
 
-    var SocketIOLoader,
+    let SocketIOLoader,
         socketLoader,
         expressApp,
         packagePath,
@@ -52,20 +54,17 @@ describe('SocketIOLoader', function () {
                 }
             }
         });
-        socketLoader = new SocketIOLoader(expressApp, options);
+        socketLoader = new SocketIOLoader(options);
     });
 
     it('throws an exception when invalid arguments and/or options are provided', function () {
         expect(function () {
-            new SocketIOLoader()
-        }).toThrow();
-        expect(function () {
-            new SocketIOLoader(expressApp, {
+            new SocketIOLoader({
                 main: [123]
             });
         }).toThrow();
         expect(function () {
-            new SocketIOLoader(expressApp, {
+            new SocketIOLoader({
                 directories: ['a/directory', 5]
             });
         }).toThrow();
@@ -73,7 +72,7 @@ describe('SocketIOLoader', function () {
 
     it('does not throw if options are not provided', function () {
         expect(function () {
-            new SocketIOLoader(expressApp);
+            new SocketIOLoader();
         }).not.toThrow();
     });
 
@@ -89,7 +88,7 @@ describe('SocketIOLoader', function () {
                 done();
             });
             
-            socketLoader.connect();
+            socketLoader.connect(expressApp);
 
             // Fake the initial and subsequent 'socket.io' connection events
             socketInstanceStub.emit('connection', socketInstanceStub);
@@ -108,8 +107,8 @@ describe('SocketIOLoader', function () {
                 done(); 
             });
             
-            socketLoader = new SocketIOLoader(expressApp, options);
-            socketLoader.connect();
+            socketLoader = new SocketIOLoader(options);
+            socketLoader.connect(expressApp);
 
             socketClientStub.emit('process-something', 'Data');
         });


### PR DESCRIPTION
- Change 'LoadServices' check to an option passed to 'Services'
- Update 'SocketIOLoader' connect API to accept a server instance
  instead of expecting one in the constructor
