### PR TITLE
Fix error logging in the ApiLoader

### DIFF
--- a/lib/api/loader.js
+++ b/lib/api/loader.js
@@ -17,21 +17,21 @@
  * apiLoader.setAPIs();             // set up the API routes on the given 'app'
  *
  * // Run all the 'Config' functions provided by the package API modules.
- * //   - 'metadata' will be passed to the config functions as the second argument
+ * //   - 'metadata' will be passed to the config functions defined by other packages
  * apiLoader.setConfig(metadata);
  *
  *  Package API module example:
  *  // packages/package-name/src/api/package-service.js
  *  var service = exports;
  *  service.Routes = [ path: '/_api/resource', httpMethod: 'GET', middleware: function (req, res, next) { ... } ];
- *  service.Config = function (expressApp, data) {
- *    // custom configuration on the express instance, etc.
+ *  service.Config = function (data) {
+ *    // custom configuration using the passed in data
  *  };
  */
 
 const path = require('path'),
     assert = require('assert'),
-    util = require('util'),
+    validateRoute = require('./validate-route'),
     _ = require('lodash'),
     {Router} = require('express'),
     apiUtils = require('./utils'),
@@ -66,13 +66,6 @@ function getConfig(serviceModule) {
     return serviceModule.Config || serviceModule.config || null;
 }
 
-function isRoute(route) {
-    return _.isObject(route)
-        && _.isString(route.httpMethod)
-        && _.isString(route.path)
-        && route.middleware;
-}
-
 /**
  * @param {Router} router - An Express JS router
  * @param {Object} route - A route definition
@@ -91,28 +84,15 @@ function hasRoute(router, route) {
  * is not valid
  *
  * @param {Object} router An Express JS router that can be extended with new routes and Express JS routers
- * @param {Object} options Overrides default settings
+ * @param {Object} options - Overrides default settings
  *
  * options:
- * {String} main
- * A relative or absolute path to a directory containing a LabShare package
- * Default: ''
- *
- * {String} pattern
- * The pattern used to match LabShare API modules
- *
- * {Object} logger
- * Error logging provider. It must define an `error` function.
- * Default: null
- *
- * {Array} directories
- * A list of paths to LabShare packages that should be searched for API modules. Directories
- * that do not contain a package.json are ignored.
- * Default: []
- *
- * {Array} ignore
- * A list of LabShare package names that should be ignored by the loader.
- * Default: []
+ * {String} options.main - A relative or absolute path to a directory containing a LabShare package. Default: ''
+ * {String} options.pattern - The pattern used to match LabShare API modules
+ * {Object} options.logger - Error logging provider. It must define an `error` function. Default: null
+ * {Array} options.directories - A list of paths to LabShare packages that should be searched for API modules. Directories
+ * that do not contain a package.json are ignored. Default: [
+ * {Array} options.ignore - A list of LabShare package names that should be ignored by the loader. Default: []
  *
  * @constructor
  */
@@ -166,7 +146,8 @@ class ApiLoader {
                 apiUtils.applyToNodeModulesSync(this.options.main, this._loadRoutes.bind(this));
             }
         } catch (error) {
-            this._handleError(new Error('Failed to load routes: ' + error.message + error.stack || error));
+            error.message = 'Failed to load routes: ' + error.message;
+            this._handleError(error);
         }
     };
 
@@ -231,7 +212,7 @@ class ApiLoader {
 
             if (configFunction) {
                 if (!_.isFunction(configFunction)) {
-                    this._handleError(new Error(`The 'Config' property provided by the module "${serviceModulePath}}" must be a function!`));
+                    this._handleError(new Error(`The 'Config' or 'config' property exported by the module "${serviceModulePath}}" must be a function!`));
                 } else {
                     this._config.push(configFunction);
                 }
@@ -252,11 +233,12 @@ class ApiLoader {
      * @private
      */
     _assignRoute(route, router, packageName) {
-        if (!isRoute(route)) {
-            this._handleError(new Error(util.format('Invalid route: %s %s from package %s ' +
-                'must define a httpMethod, a path, and middleware', route.httpMethod || '?', route.path || 'unknown', packageName)));
+        let routeValidation = validateRoute(route, packageName);
+        if (!routeValidation.isValid) {
+            this._handleError(new Error(routeValidation.message));
             return;
         }
+
         if (hasRoute(router, route)) {
             return;
         }
@@ -290,7 +272,7 @@ class ApiLoader {
 
     _handleError(error) {
         if (this.options.logger) {
-            this.options.logger.error(error);
+            this.options.logger.error(error.stack || error.message || error);
             return;
         }
         throw error;

--- a/lib/api/validate-route.js
+++ b/lib/api/validate-route.js
@@ -1,0 +1,55 @@
+'use strict';
+
+const revalidator = require('revalidator'),
+    _ = require('lodash');
+
+/**
+ * @description Checks if the given route has the required properties
+ * @param {object} route
+ * @param {string} packageName - The name of a LabShare package
+ * @returns {{message: string, isValid: boolean}}
+ */
+module.exports = function validateRoute(route, packageName) {
+    let validation = revalidator.validate(route, {
+            properties: {
+                httpMethod: {
+                    type: 'string',
+                    required: true,
+                    allowEmpty: false
+                },
+                path: {
+                    type: 'string',
+                    required: true,
+                    allowEmpty: false
+                },
+                middleware: {
+                    // type: ['array', 'object'],
+                    conform: middleware => {
+                        return _.isFunction(middleware) || _.isArray(middleware);
+                    },
+                    messages: {
+                        conform: 'middleware must be a function or an array of functions'
+                    },
+                    required: true,
+                    allowEmpty: false
+                },
+                accessLevel: {
+                    required: false,
+                    allowEmpty: false
+                }
+            }
+        }, {
+            additionalProperties: false
+        }
+    );
+
+    var message = `Invalid route "${JSON.stringify(route)}" from package "${packageName}": `;
+    validation.errors.forEach((error, index) => {
+        message += error.property + ' ' + error.message + ((index < validation.errors.length - 1) ? ', ' : '. ');
+    });
+
+    return {
+        message,
+        isValid: validation.valid
+    };
+};

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "services",
   "namespace": "",
   "main": "./",
-  "version": "v0.16.609",
+  "version": "v0.16.614",
   "description": "LabShare API service manager",
   "private": true,
   "contributors": "https://github.com/LabShare/services/graphs/contributors",

--- a/test/lib/unit/api/loader_spec.js
+++ b/test/lib/unit/api/loader_spec.js
@@ -1,8 +1,10 @@
-var path = require('path'),
+'use strict';
+
+const path = require('path'),
     proxyquire = require('proxyquire'),
     supertest = require('supertest-as-promised'),
     express = require('express'),
-    Router = require('express').Router,
+    {Router} = express,
     Q = require('q'),
     _ = require('lodash');
 
@@ -10,10 +12,6 @@ require('promise-matchers');
 
 function allArgs(spy) {
     return _.flatten(_.map(spy.calls, 'args'));
-}
-
-function allArgErrorMessages(spy) {
-    return _.map(allArgs(spy), 'message');
 }
 
 describe('ApiLoader', function () {
@@ -126,13 +124,12 @@ describe('ApiLoader', function () {
             apiLoader.initialize();
             apiLoader.setAPIs();
 
-            var errors = allArgErrorMessages(options.logger.error),
-                expectedErrorSuffix = 'must define a httpMethod, a path, and middleware';
+            var errors = allArgs(options.logger.error).join(' ');
 
-            expect(errors).toContain('Invalid HTTP method specified for route /list/:listName/items/:id from package api-package-2');
-            expect(errors).toContain('Invalid route: POST unknown from package api-package-2 ' + expectedErrorSuffix);
-            expect(errors).toContain('Invalid route: DELETE /list/:listName/items/:id from package api-package-2 ' + expectedErrorSuffix);
-            expect(errors).toContain('Invalid route: ? /documents from package api-package-2 ' + expectedErrorSuffix);
+            expect(errors).toContain('Error: Invalid HTTP method specified for route /list/:listName/items/:id from package api-package-2');
+            expect(errors).toContain('Error: Invalid route "{"httpMethod":"POST","middleware":[null]}" from package "api-package-2": path is required');
+            expect(errors).toContain('Error: Invalid route "{"path":"/list/:listName/items/:id","httpMethod":"DELETE"}" from package "api-package-2": middleware is required');
+            expect(errors).toContain('Error: Invalid route "{"path":"/documents","middleware":[null]}" from package "api-package-2": httpMethod is required');
         });
 
         it('throws exceptions for invalid routes if a logger is not provided', function () {


### PR DESCRIPTION
- Improve route validation by using the 'revalidator' library instead
