### PR TITLE
Breaking Change: Remove global.LabShare.UserRoles and .AccessLevels a…

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,10 @@
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/3b8ace2fa2784cf29a19a3f2dfd3cc60)](https://www.codacy.com?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=LabShare/services&amp;utm_campaign=Badge_Grade)
 [![Build Status](https://travis-ci.com/LabShare/services.svg?token=Y1xBXqo2AsyTGxuGHcYM&branch=master)](https://travis-ci.com/LabShare/services)
 
-
 ## Working with LabShare APIs
 ### [Running APIs](docs/run-package.md)
-### [Adding new APIs](docs/package-apis.md)
+### [Adding HTTP APIs](docs/http-apis.md)
+### [Adding Socket APIs](docs/socket-apis.md)
 ### [Managing APIs with PM2](docs/pm2-services.md)
 
 ## Development

--- a/cli/init.js
+++ b/cli/init.js
@@ -1,8 +1,0 @@
-'use strict';
-
-module.exports = function init(done) {
-    global.LabShare.UserRoles = require('../lib/auth').UserRoles;
-    global.LabShare.AccessLevels = require('../lib/auth').AccessLevels;
-
-    done();
-};

--- a/docs/http-apis.md
+++ b/docs/http-apis.md
@@ -1,8 +1,4 @@
-# Working with Package APIs (HTTP and Sockets)
-
-## HTTP APIs
-
-### How to add new HTTP APIs
+### HTTP APIs
 
 To define new HTTP APIs, create CommonJS modules inside the 'api' directory of
 your project.  Each API module must define a `Routes` or `routes`
@@ -24,11 +20,11 @@ function hello(request, response, next) {
     response.send('Hello world!');
 }
 helloService.routes = [
-    { path: '/hello', httpMethod: 'GET', middleware: hello, accessLevel: 'user' }
+    { path: '/hello', httpMethod: 'GET', middleware: hello }
 ]
 ```
 
-After running `lsc services start` in the package's root directory, the API server will start up and include the route '/hello' (e.g.
+After running `lsc services start` in the package's root directory, the API server will start up and being responding to the route '/hello' (e.g.
 'http://localhost:8000/hello-package/hello'). The route is namespaced by the package name.
 
 Note:
@@ -68,53 +64,3 @@ The instantiated `services` contains the following public properties:
 | start | Function | Starts all the API routes and Socket connections. |
 | io | Function | Returns an instance of `Socket.IO` |
 | app | Object | The Express app instance |
-
-
-## Socket.io APIs
-
-### How to add new Socket.io connections
-
-Create Node modules inside the 'api' directory of your package that export a
-'onConnect' function. The 'onConnect' function will receive a socket at start
-up as the first argument. You can assign event listeners and handlers to the
-socket as needed.
-
-Example:
-
-```javascript
-// ls-hello/api/hellosocket.js
-exports.onConnect = function (socket) {
-    socket.emit('connected', 'Hi there!');
-    socket.on('some-awesome-event', function (excitingData) {
-        // do something
-    });
-    // ...
-}
-```
-
-### Configuring services for P2P socket communication
-
-The `Services` package has a configuration value for establishing socket
-communication between other LabShare packages using `Services`. In other words, `Services` can act as both a server and a client using sockets. Add the host names and the Socket.IO
-package namespaces to the list of socket connections in `Socket.Connections`:
-
-Example:
-
-```json
-// config.json
-{
- "services": {
-    "Socket": {
-        "Connections": [
-            "http://host1.org/namespace1",
-            "http://host2.org/namespace2"
-        ]
-    }
- }
-}
-```
-
-With the above configuration, `services` will attempt to establish a socket
-connection to `host1` and `host2`. Broadcasting an event
-from your LabShare package would invoke the listeners set up in the `onConnect`
-functions of `host1` and `host2`.

--- a/docs/socket-apis.md
+++ b/docs/socket-apis.md
@@ -1,0 +1,48 @@
+## Socket.io APIs
+
+### How to add new Socket.io connections
+
+Create Node modules inside the 'api' directory of your package that export a
+'onConnect' function. The 'onConnect' function will receive a socket at start
+up as the first argument. You can assign event listeners and handlers to the
+socket as needed.
+
+Example:
+
+```javascript
+// ls-hello/api/hellosocket.js
+exports.onConnect = function (socket) {
+    socket.emit('connected', 'Hi there!');
+    socket.on('some-awesome-event', function (excitingData) {
+        // do something
+    });
+    // ...
+}
+```
+
+### Configuring services for P2P socket communication
+
+The `Services` package has a configuration value for establishing socket
+communication between other LabShare packages using `Services`. In other words, `Services` can act as both a server and a client using sockets. Add the host names and the Socket.IO
+package namespaces to the list of socket connections in `Socket.Connections`:
+
+Example:
+
+```json
+// config.json
+{
+ "services": {
+    "Socket": {
+        "Connections": [
+            "http://host1.org/namespace1",
+            "http://host2.org/namespace2"
+        ]
+    }
+ }
+}
+```
+
+With the above configuration, `services` will attempt to establish a socket
+connection to `host1` and `host2`. Broadcasting an event
+from your LabShare package would invoke the listeners set up in the `onConnect`
+functions of `host1` and `host2`.

--- a/lib/auth/ensure-authorized.js
+++ b/lib/auth/ensure-authorized.js
@@ -1,17 +1,18 @@
-var {userRoles, accessLevels} = require('./user-roles'),
+'use strict';
+
+const {userRoles, accessLevels} = require('./user-roles'),
     assert = require('assert'),
     _ = require('lodash');
 
 /**
  * @description Role-based authorization middleware
- *
  * @param {Object} route A route definition
  */
 module.exports = function ensureAuthorized(route) {
     assert.ok(_.isObject(route), '`route` must be an object');
 
     function authorize(req, res, next) {
-        var role;
+        let role;
         if (!req.user) {
             role = userRoles.public;
         } else {
@@ -20,10 +21,12 @@ module.exports = function ensureAuthorized(route) {
                 role = userRoles[req.user.role];
             }
         }
-        var accessLevel = route.accessLevel || accessLevels.public;
-        if (!(accessLevel.bitMask & role.bitMask))
+        let accessLevel = accessLevels[route.accessLevel || 'public'];
+        if (!(accessLevel.bitMask & role.bitMask)) {
             return res.sendStatus(403);
-        return next();
+        }
+
+        next();
     }
 
     return authorize;

--- a/lib/auth/index.js
+++ b/lib/auth/index.js
@@ -1,6 +1,4 @@
 module.exports = {
-    UserRoles: require('./user-roles').userRoles,
-    AccessLevels: require('./user-roles').accessLevels,
     EnsureAuthorized: require('./ensure-authorized'),
     Restrict: require('./restrict'),
     User: require('./user')

--- a/lib/auth/user-roles.js
+++ b/lib/auth/user-roles.js
@@ -1,5 +1,7 @@
-(function (exports) {
-    var config = {
+'use strict';
+
+const assert = require('assert'),
+    config = {
 
         // There is a max of 31 roles before the bit shift pushes the accompanying integer out of
         // the memory footprint for an integer
@@ -21,77 +23,78 @@
         }
     };
 
-    /**
-     * @description Builds a distinct bit mask for each role. It starts off with "1"
-     * and shifts the bit to the left for each element in the given roles array.
-     * @param {Array} roles
-     * @returns {Object}
-     */
-    function buildRoles(roles) {
-        var bitMask = "01";
-        var userRoles = {};
-        for (var role in roles) {
-            if (roles.hasOwnProperty(role)) {
-                var intCode = parseInt(bitMask, 2);
-                userRoles[roles[role]] = {
-                    bitMask: intCode,
-                    title: roles[role]
-                };
-                bitMask = (intCode << 1 ).toString(2);
-            }
+/**
+ * @description Builds a distinct bit mask for each role. It starts off with "1"
+ * and shifts the bit to the left for each element in the given roles array.
+ * @param {Array} roles
+ * @returns {Object}
+ */
+function buildRoles(roles) {
+    let bitMask = '01',
+        userRoles = {};
+
+    for (let role in roles) {
+        if (roles.hasOwnProperty(role)) {
+            let intCode = parseInt(bitMask, 2);
+            userRoles[roles[role]] = {
+                bitMask: intCode,
+                title: roles[role]
+            };
+            bitMask = (intCode << 1).toString(2);
         }
-        return userRoles;
     }
+    return userRoles;
+}
 
-    /**
-     * @description Builds access level bit masks based on the accessLevelDeclaration parameter which must
-     * contain an array for each access level containing the allowed user roles.
-     * @param accessLevelDeclarations
-     * @param userRoles
-     * @returns {Object}
-     */
-    function buildAccessLevels(accessLevelDeclarations, userRoles) {
-        var accessLevels = {},
-            resultBitMask,
-            role;
+/**
+ * @description Builds access level bit masks based on the accessLevelDeclaration parameter which must
+ * contain an array for each access level containing the allowed user roles.
+ * @param accessLevelDeclarations
+ * @param userRoles
+ * @returns {Object}
+ */
+function buildAccessLevels(accessLevelDeclarations, userRoles) {
+    let accessLevels = {},
+        resultBitMask,
+        role;
 
-        for (var level in accessLevelDeclarations) {
-            if (accessLevelDeclarations.hasOwnProperty(level)) {
-                if (typeof accessLevelDeclarations[level] === 'string') {
-                    if (accessLevelDeclarations[level] === '*') {
-                        resultBitMask = '';
-                        for (role in userRoles) {
-                            resultBitMask += "1";
-                        }
-                        accessLevels[level] = {
-                            bitMask: parseInt(resultBitMask, 2),
-                            title: accessLevelDeclarations[level]
-                        };
-                    } else {
-                        console.error("Access Control Error: Could not parse '" +
-                        accessLevelDeclarations[level] + "' as access definition for level '" + level + "'");
-                    }
-                } else {
-                    resultBitMask = 0;
-                    for (role in accessLevelDeclarations[level]) {
-                        if (userRoles.hasOwnProperty(accessLevelDeclarations[level][role])) {
-                            resultBitMask = resultBitMask | userRoles[accessLevelDeclarations[level][role]].bitMask;
-                        } else {
-                            console.error("Access Control Error: Could not find role '" +
-                            accessLevelDeclarations[level][role] +
-                            "' in registered roles while building access for '" + level + "'");
-                        }
+    for (let level in accessLevelDeclarations) {
+        if (accessLevelDeclarations.hasOwnProperty(level)) {
+            if (typeof accessLevelDeclarations[level] === 'string') {
+                if (accessLevelDeclarations[level] === '*') {
+                    resultBitMask = '';
+                    for (role in userRoles) {
+                        resultBitMask += "1";
                     }
                     accessLevels[level] = {
-                        bitMask: resultBitMask,
-                        title: accessLevelDeclarations[level][role]
+                        bitMask: parseInt(resultBitMask, 2),
+                        title: accessLevelDeclarations[level]
                     };
+                } else {
+                    console.error("Access Control Error: Could not parse '" +
+                        accessLevelDeclarations[level] + "' as access definition for level '" + level + "'");
                 }
+            } else {
+                resultBitMask = 0;
+                for (role in accessLevelDeclarations[level]) {
+                    if (userRoles.hasOwnProperty(accessLevelDeclarations[level][role])) {
+                        resultBitMask = resultBitMask | userRoles[accessLevelDeclarations[level][role]].bitMask;
+                    } else {
+                        console.error("Access Control Error: Could not find role '" +
+                            accessLevelDeclarations[level][role] +
+                            "' in registered roles while building access for '" + level + "'");
+                    }
+                }
+                accessLevels[level] = {
+                    bitMask: resultBitMask,
+                    title: accessLevelDeclarations[level][role]
+                };
             }
         }
-        return accessLevels;
     }
 
-    exports.userRoles = buildRoles(config.roles);
-    exports.accessLevels = buildAccessLevels(config.accessLevels, exports.userRoles);
-})(typeof exports === 'undefined' ? this['routingConfig'] = {} : exports);
+    return accessLevels;
+}
+
+exports.userRoles = buildRoles(config.roles);
+exports.accessLevels = buildAccessLevels(config.accessLevels, exports.userRoles);

--- a/test/fixtures/main-package/node_modules/api-package1/api/access-test-service.js
+++ b/test/fixtures/main-package/node_modules/api-package1/api/access-test-service.js
@@ -2,8 +2,6 @@
 
 'use strict';
 
-const {AccessLevels} = require('../../../../../../lib/auth');
-
 function api1Service () {
 
     var successResponse = function (req, res) {
@@ -11,10 +9,10 @@ function api1Service () {
     };
 
     var routes = [
-        { path: '/access-public', httpMethod: 'GET', middleware: successResponse, accessLevel: AccessLevels.public },
-        { path: '/access-user', httpMethod: 'GET', middleware: successResponse, accessLevel: AccessLevels.public },
-        { path: '/access-staff', httpMethod: 'GET', middleware: successResponse, accessLevel: AccessLevels.public },
-        { path: '/access-admin', httpMethod: 'GET', middleware: successResponse, accessLevel: AccessLevels.public }
+        { path: '/access-public', httpMethod: 'GET', middleware: successResponse, accessLevel: 'public' },
+        { path: '/access-user', httpMethod: 'GET', middleware: successResponse, accessLevel: 'public' },
+        { path: '/access-staff', httpMethod: 'GET', middleware: successResponse, accessLevel: 'public' },
+        { path: '/access-admin', httpMethod: 'GET', middleware: successResponse, accessLevel: 'public' }
     ];
 
     return {

--- a/test/lib/unit/auth/ensure-authorized_spec.js
+++ b/test/lib/unit/auth/ensure-authorized_spec.js
@@ -1,7 +1,6 @@
-var accessLevels = require('../../../../lib/auth').AccessLevels,
-    userRoles = require('../../../../lib/auth').UserRoles;
+'use strict';
 
-describe('ensureAuthorized', function () {
+describe('ensureAuthorized', () => {
 
     var ensureAuthorized,
         middleware,
@@ -10,7 +9,7 @@ describe('ensureAuthorized', function () {
         route,
         next;
 
-    beforeEach(function () {
+    beforeEach(() => {
         requestMock = jasmine.createSpy('request');
         responseMock = {
             sendStatus: jasmine.createSpy('send')
@@ -20,17 +19,17 @@ describe('ensureAuthorized', function () {
         ensureAuthorized = require('../../../../lib/auth/ensure-authorized');
     });
 
-    it('throws with invalid arguments', function () {
-        expect(function () {
+    it('throws with invalid arguments', () => {
+        expect(() => {
             ensureAuthorized(null);
         }).toThrow();
     });
 
-    it('allows users to access routes that match their role', function () {
-        route = { accessLevel: accessLevels.public };
+    it('allows users to access routes that match their role', () => {
+        route = { accessLevel: 'public' };
         middleware = ensureAuthorized(route);
         requestMock.user = {
-            role: userRoles.public
+            role: 'public'
         };
 
         middleware(requestMock, responseMock, next);
@@ -38,8 +37,8 @@ describe('ensureAuthorized', function () {
         expect(next).toHaveBeenCalled();
     });
 
-    it('prevents users from accessing routes that do not match their role', function () {
-        route = { accessLevel: accessLevels.admin };
+    it('prevents users from accessing routes that do not match their role', () => {
+        route = { accessLevel: 'admin' };
         middleware = ensureAuthorized(route);
         requestMock.user = null;
 
@@ -48,11 +47,11 @@ describe('ensureAuthorized', function () {
         expect(responseMock.sendStatus).toHaveBeenCalledWith(403);
     });
 
-    it('defaults to accessLevel "public" if a route does not define an "accessLevel"', function () {
+    it('defaults to accessLevel "public" if a route does not define an "accessLevel"', () => {
         route = { accessLevel: null };
         middleware = ensureAuthorized(route);
         requestMock.user = {
-            role: userRoles.public
+            role: 'public'
         };
 
         middleware(requestMock, responseMock, next);
@@ -60,7 +59,7 @@ describe('ensureAuthorized', function () {
         expect(next).toHaveBeenCalled();
     });
 
-    it('allows userRoles to be aliased as strings (e.g. "public" gets converted to {bitMask: 1, title: "public"})', function () {
+    it('allows userRoles to be aliased as strings', () => {
         route = { accessLevel: null };
         middleware = ensureAuthorized(route);
         requestMock.user = {


### PR DESCRIPTION
…ssignment

 - Fixes #21
 - Developers creating APIs will need to specify the route 'accessLevel' using a string (e.g. 'public', 'user', 'staff', 'admin') instead of accessing a global.
 - Restructure documentation to separate the HTTP and Socket API creation