### PR TITLE
Run the package config functions after initialize() instead of during

### DIFF
--- a/lib/services.js
+++ b/lib/services.js
@@ -78,14 +78,6 @@ class Services {
         }));
 
         this._apiLoader.initialize();
-
-        // Run all the package API 'config' functions
-        this._apiLoader.setConfig(_.extend(this._options.data, {
-            services: this,
-            apiLoader: this._apiLoader,
-            express,
-            app: this.app
-        }));
     }
 
     /**
@@ -116,6 +108,14 @@ class Services {
         if (!this._initialized) {
             this.initialize();
         }
+
+        // Run all the package API 'config' functions
+        this._apiLoader.setConfig(_.extend(this._options.data, {
+            services: this,
+            apiLoader: this._apiLoader,
+            express,
+            app: this.app
+        }));
 
         this._servicesActive = true;
 


### PR DESCRIPTION
This prevents an issue where routes are attached to the Express instance before they are modified by a Service.config() call.