### PR TITLE
Fix bug with route namespacing

### DIFF
--- a/lib/api/route.js
+++ b/lib/api/route.js
@@ -1,7 +1,8 @@
 'use strict';
 
 const validateRoute = require('./validate-route'),
-    _ = require('lodash');
+    _ = require('lodash'),
+    assert = require('assert');
 
 function normalize(url) {
     return url
@@ -10,7 +11,7 @@ function normalize(url) {
 }
 
 function joinUrl(...args) {
-    var url = args.join('/');
+    let url = args.join('/');
     return normalize(url);
 }
 
@@ -29,6 +30,8 @@ class Route {
      * @param {Array|Function} options.middleware - One or more Express.JS middleware functions
      */
     constructor(packageName, options = {}) {
+        assert.ok(_.isString(packageName), 'Route: "packageName" is required');
+
         let validator = validateRoute(options, packageName);
         if (!validator.isValid) {
             throw new Error(validator.message);
@@ -38,8 +41,12 @@ class Route {
 
         this.middleware = toArray(this.middleware);
 
+        if (!this.path.startsWith('/')) {
+            this.path = `/${this.path}`;
+        }
+
         // Namespace the API path with the LabShare package name
-        if (!this.path.startsWith(`/${packageName}`)) {
+        if (!this.path.startsWith(`/${packageName}/`)) {
             this.path = joinUrl('/', packageName, this.path);
         }
     }

--- a/lib/api/validate-route.js
+++ b/lib/api/validate-route.js
@@ -31,10 +31,6 @@ module.exports = function validateRoute(route, packageName) {
                     },
                     required: true,
                     allowEmpty: false
-                },
-                accessLevel: {
-                    required: false,
-                    allowEmpty: false
                 }
             }
         }

--- a/lib/services.js
+++ b/lib/services.js
@@ -29,7 +29,7 @@ class Services {
      * @param {Array} [options.ignore] - A list of LabShare package names that should be ignored by the API and Socket loaders. Default: []
      */
     constructor(options = {}) {
-        this.app = express();
+        this._app = express();
         this._initialized = false;
         this._servicesActive = false;
         this._options = _.defaults(options, {
@@ -42,7 +42,7 @@ class Services {
             loadServices: true
         });
         this._siteActive = false;
-        this._apiLoader = new Loader(this.app, this._options);
+        this._apiLoader = new Loader(this._app, this._options);
         this._socketLoader = new SocketIOLoader(this._options);
     }
 
@@ -56,20 +56,20 @@ class Services {
 
         let requestLoggingMode = serverUtils.isDevMode() ? 'dev' : 'combined';
 
-        this.app.use(bodyParser.json());
-        this.app.use(bodyParser.urlencoded({extended: true}));
-        this.app.use(cors());
+        this._app.use(bodyParser.json());
+        this._app.use(bodyParser.urlencoded({extended: true}));
+        this._app.use(cors());
 
         // Workaround to add fluentD integration with the morgan logging library
         if (_.get(this._options, 'logger.stream.write')) {
-            this.app.use(morgan(requestLoggingMode, {stream: this._options.logger.stream}));
+            this._app.use(morgan(requestLoggingMode, {stream: this._options.logger.stream}));
         } else {
-            this.app.use(morgan(requestLoggingMode));
+            this._app.use(morgan(requestLoggingMode));
         }
 
-        this.app.use(cookieParser());
+        this._app.use(cookieParser());
 
-        this.app.use(require('express-session')({
+        this._app.use(require('express-session')({
             secret: _.get(global.LabShare, 'Config.services.Secret') || require('crypto').randomBytes(64).toString('hex'),
             resave: false,
             saveUninitialized: false
@@ -94,7 +94,7 @@ class Services {
         
         func({
             services: this._apiLoader.services,
-            app: this.app
+            app: this._app
         });
     }
 
@@ -112,12 +112,12 @@ class Services {
             services: this,
             apiLoader: this._apiLoader,
             express,
-            app: this.app
+            app: this._app
         }));
 
         this._servicesActive = true;
 
-        let server = serverUtils.startServer(this.app, this._options.logger);
+        let server = serverUtils.startServer(this._app, this._options.logger);
 
         // add API routes and socket connections unless configured not to
         if (this._options.loadServices) {
@@ -147,7 +147,7 @@ class Services {
      */
     expressStatic({mountPoint, root, options}) {
         this._siteActive = true;
-        this.app.use(mountPoint, express.static(root, options));
+        this._app.use(mountPoint, express.static(root, options));
     }
 
     /**

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "services",
   "namespace": "",
   "main": "./",
-  "version": "v0.16.1212",
+  "version": "v0.16.1214",
   "description": "LabShare API service manager",
   "private": true,
   "contributors": "https://github.com/LabShare/services/graphs/contributors",

--- a/test/lib/unit/api/route_spec.js
+++ b/test/lib/unit/api/route_spec.js
@@ -1,0 +1,72 @@
+'use strict';
+
+const path = require('path');
+
+describe('Route', () => {
+
+    let Route,
+        packageName;
+
+    beforeEach(() => {
+        packageName = 'session';
+        Route = require('../../../../lib/api/route');
+    });
+
+    it('throws an exception when it fails validation', () => {
+        let packageName = 'session';
+
+        expect(() => {
+            new Route(packageName, {})
+        }).toThrowError(/Invalid route.*/);
+
+        expect(() => {
+            new Route(packageName, {
+                httpMethod: 'GET',
+                middleware: [() => {}]
+            })
+        }).toThrowError(/path is required/);
+
+        expect(() => {
+            new Route(packageName, {
+                middleware: [() => {}],
+                path: '/my/api'
+            })
+        }).toThrowError(/httpMethod is required/);
+
+        expect(() => {
+            new Route(packageName, {
+                httpMethod: 'GET',
+                path: '/my/api'
+            })
+        }).toThrowError(/middleware is required/);
+    });
+
+    it('namespaces the path with the package name', () => {
+        let route = new Route(packageName, {
+            httpMethod: 'GET',
+            middleware: [() => {}],
+            path: '/my/api'
+        });
+
+        expect(route.path).toBe(`/${packageName}/my/api`);
+
+        route = new Route(packageName, {
+            httpMethod: 'GET',
+            middleware: [() => {}],
+            path: '/sessions/my/api'
+        });
+
+        expect(route.path).toBe(`/${packageName}/sessions/my/api`);
+    });
+
+    it('does not duplicate the package namespace', () => {
+        let route = new Route(packageName, {
+            httpMethod: 'GET',
+            middleware: [() => {}],
+            path: `${packageName}/my/api`  // leading slash intentionally omitted
+        });
+
+        expect(route.path).toBe(`/${packageName}/my/api`);
+    });
+
+});


### PR DESCRIPTION
If the package name was a subset of the route path, the namespace
was not being applied.

 - Add 'Route' unit tests
 - Change 'app' a private variable in the Services class
 - Version