### PR TITLE
Enable secure cookies in production

### DIFF
--- a/docs/http-apis.md
+++ b/docs/http-apis.md
@@ -51,16 +51,12 @@ By default, the config function will be called with an object containing the fol
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| express | Object | The ExpressJS library |
 | apiLoader | Object | A ApiLoader instance. It contains methods for assigning APIs and running global API config functions. |
-| services | Object | A `Services` class instance. It contains methods related to loading and starting API services. |
 | app | Object | The Express router instance used by the `Services` class. |
 
-The instantiated `services` contains the following public properties:
+The instantiated `services` contains the following public methods:
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| isSiteActive | Function | Returns true after `services.expressStatic` is called. |
 | start | Function | Starts all the API routes and Socket connections. |
 | io | Function | Returns an instance of `Socket.IO` |
-| app | Object | The Express app instance |

--- a/lib/services.js
+++ b/lib/services.js
@@ -41,7 +41,6 @@ class Services {
             data: {},
             loadServices: true
         });
-        this._siteActive = false;
         this._apiLoader = new Loader(this._app, this._options);
         this._socketLoader = new SocketIOLoader(this._options);
     }
@@ -69,11 +68,20 @@ class Services {
 
         this._app.use(cookieParser());
 
-        this._app.use(require('express-session')({
+        let sessionOptions = {
             secret: _.get(global.LabShare, 'Config.services.Secret') || require('crypto').randomBytes(64).toString('hex'),
             resave: false,
-            saveUninitialized: false
-        }));
+            saveUninitialized: false,
+            cookie: {}
+        };
+
+        // See: https://github.com/expressjs/session#cookiesecure
+        if (this._app.get('env') === 'production') {
+            this._app.set('trust proxy', 1);      // trust first proxy
+            sessionOptions.cookie.secure = true;  // serve secure cookies
+        }
+
+        this._app.use(require('express-session')(sessionOptions));
 
         this._apiLoader.initialize();
     }
@@ -91,7 +99,7 @@ class Services {
         if (this._servicesActive) {
             throw new Error('You cannot modify the LabShare API services after starting up the server!');
         }
-        
+
         func({
             services: this._apiLoader.services,
             app: this._app
@@ -109,9 +117,7 @@ class Services {
 
         // Run all the package API 'config' functions
         this._apiLoader.setConfig(_.extend(this._options.data, {
-            services: this,
             apiLoader: this._apiLoader,
-            express,
             app: this._app
         }));
 
@@ -137,25 +143,6 @@ class Services {
         } else {
             this._options.logger.warn('API services are disabled because Service\'s `options.loadServices` is missing or set to false!');
         }
-    }
-
-    /**
-     *
-     * @param {String} mountPoint
-     * @param {String} root
-     * @param {Object} options
-     */
-    expressStatic({mountPoint, root, options}) {
-        this._siteActive = true;
-        this._app.use(mountPoint, express.static(root, options));
-    }
-
-    /**
-     *
-     * @returns {boolean}
-     */
-    isSiteActive() {
-        return this._siteActive;
     }
 
     io() {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "services",
   "namespace": "",
   "main": "./",
-  "version": "v0.16.1214",
+  "version": "v0.16.1220",
   "description": "LabShare API service manager",
   "private": true,
   "contributors": "https://github.com/LabShare/services/graphs/contributors",


### PR DESCRIPTION
 - Remove express.static wrappers from Services
 - Only pass in the apiLoader and the express app to LabShare package config functions by default
 - Update docs