### PR TITLE
Change LabShare service to a scoped module

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,10 @@
 
 ## Usage
 
+`npm i @ls/services`
+
 ```js
-const {Services} = require('services');
+const {Services} = require('@ls/services');
 
 let options = {
     // Override default options
@@ -34,9 +36,9 @@ services.start();
 ### [Managing APIs with PM2](docs/pm2-services.md)
 
 ## Development
-1. Install Node.js from https://nodejs.org/.
-2. Globally install the LabShare CLI manager LSC: `npm i -g lsc`.
-3. Run `npm install` inside the Service package's root directory to install its dependencies.
+1. Install [Node.js](https://nodejs.org).
+2. `npm i -g lsc`
+3. Run `npm install` inside the Service's root directory to install its dependencies.
 
 ### Tests
-Run the Service's unit tests with `npm test`.
+`npm test`

--- a/lib/api/utils.js
+++ b/lib/api/utils.js
@@ -12,13 +12,13 @@ const glob = require('glob'),
     _ = require('lodash');
 
 /**
- * @param manifest A LabShare package package.json
- * @returns {Object} Containing LabShare package dependencies or an empty object
+ * @param manifest - A parsed LabShare package package.json file
+ * @returns {Array} A list of LabShare package dependencies or an empty array
  */
 exports.getPackageDependencies = function getPackageDependencies(manifest) {
-    return (_.isObject(manifest) && _.isPlainObject(manifest.packageDependencies))
-        ? manifest.packageDependencies
-        : {};
+    return (_.isObject(manifest) && _.isObject(manifest.packageDependencies))
+        ? (_.isArray(manifest.packageDependencies) ? manifest.packageDependencies : Object.keys(manifest.packageDependencies))
+        : [];
 };
 
 /**
@@ -41,7 +41,7 @@ exports.getMatchingFilesSync = function (directory, pattern) {
  */
 exports.isIgnored = function (manifest, ignored) {
     return manifest && exports.getPackageName(manifest)
-        && _.some(ignored, function isIgnored(name) {
+        && _.some(ignored, name => {
             return manifest.name === name || manifest.namespace === name;
         })
 };
@@ -143,7 +143,7 @@ exports.applyToNodeModulesSync = function applyToNodeModulesSync(directory, func
         func.call(thisArg, packagePath);
         loadedDependencies[id] = true;
 
-        _.each(dependencies, (version, dependencyName) => {
+        _.each(dependencies, dependencyName => {
             let dependencyPath = path.join(directory, 'node_modules', dependencyName);
             if (!exports.isPackageSync(dependencyPath)) {
                 throw new Error(`Package dependency: "${dependencyName}" does not exist in "${dependencyPath}". Make sure it is installed!`);
@@ -195,7 +195,7 @@ exports.applyToNodeModules = function applyToNodeModules(directory, func, thisAr
 
         loadedDependencies[id] = true;
 
-        _.each(dependencies, (version, dependencyName) => {
+        _.each(dependencies, dependencyName => {
             let dependencyPath = path.join(directory, 'node_modules', dependencyName);
             if (!exports.isPackageSync(dependencyPath)) {
                 promises.push(Q.reject(new Error(`Package dependency: "${dependencyName}" does not exist in "${dependencyPath}". Make sure it is installed!`)));

--- a/package.json
+++ b/package.json
@@ -1,10 +1,9 @@
 {
-  "name": "services",
-  "namespace": "",
+  "name": "@ls/services",
+  "namespace": "services",
   "main": "./",
-  "version": "v0.16.0104",
+  "version": "v0.16.0119",
   "description": "LabShare API service manager",
-  "private": true,
   "contributors": "https://github.com/LabShare/services/graphs/contributors",
   "repository": {
     "type": "git",

--- a/test/lib/unit/api/utils_spec.js
+++ b/test/lib/unit/api/utils_spec.js
@@ -3,13 +3,13 @@
 const proxyquire = require('proxyquire'),
     path = require('path');
 
-describe('PackageUtils', function () {
+describe('PackageUtils', () => {
 
     let packageUtils,
         directory,
         fsMock;
 
-    beforeEach(function () {
+    beforeEach(() => {
         directory = path.join('path', 'to', 'dir');
         fsMock = jasmine.createSpyObj('fs', ['readdirSync', 'lstatSync', 'unlinkSync', 'realpathSync', 'realpath']);
         packageUtils = proxyquire('../../../../lib/api/utils', {
@@ -17,25 +17,25 @@ describe('PackageUtils', function () {
         });
     });
 
-    describe('.isPackageSync()', function () {
+    describe('.isPackageSync()', () => {
 
         let packagesPath;
 
-        beforeEach(function () {
+        beforeEach(() => {
             packageUtils = require('../../../../lib/api/utils');
             packagesPath = './test/fixtures';
         });
 
-        it('checks if a directory contains a LabShare package', function () {
+        it('checks if a directory contains a LabShare package', () => {
             expect(packageUtils.isPackageSync(packagesPath)).toBeFalsy();
             expect(packageUtils.isPackageSync(path.join(packagesPath, 'main-package'))).toBeTruthy();
         });
 
     });
 
-    describe('.getPackageName', function () {
+    describe('.getPackageName', () => {
 
-        it('finds the name of a package from its manifest', function () {
+        it('finds the name of a package from its manifest', () => {
             expect(packageUtils.getPackageName(null)).toBeNull();
             expect(packageUtils.getPackageName()).toBeNull();
             expect(packageUtils.getPackageName({})).toBeNull();
@@ -51,74 +51,73 @@ describe('PackageUtils', function () {
 
     });
 
-    describe('.getPackageDependencies', function () {
+    describe('.getPackageDependencies', () => {
 
-        it('returns an object containing the package\'s LabShare package dependencies', function () {
-            var manifest = {
+        it('returns an object containing the package\'s LabShare package dependencies', () => {
+            let manifest = {
                 "name": "name",
                 "dependencies": {
                     "lodash": "*"
                 },
-                "packageDependencies": {
-                    "foo": "1.5.9"
-                }
+                "packageDependencies": [
+                    'foo'
+                ]
+
             };
-            expect(packageUtils.getPackageDependencies(manifest)).toEqual({
-                "foo": "1.5.9"
-            });
+            expect(packageUtils.getPackageDependencies(manifest)).toEqual(['foo']);
         });
 
-        it('returns an empty object if the package does not specify dependencies or the dependencies could not be read', function () {
-            var noPackageDeps = {
+        it('returns an empty object if the package does not specify dependencies or the dependencies could not be read', () => {
+            let noPackageDeps = {
                     "name": "name",
                     "dependencies": {
                         "lodash": "*"
                     }
                 },
                 invalidDepDefinition = {
-                    "packageDependencies": []
+                    "packageDependencies": 123
 
                 };
-            expect(packageUtils.getPackageDependencies(noPackageDeps)).toEqual({});
-            expect(packageUtils.getPackageDependencies(null)).toEqual({});
-            expect(packageUtils.getPackageDependencies(invalidDepDefinition)).toEqual({});
+            expect(packageUtils.getPackageDependencies(noPackageDeps)).toEqual([]);
+            expect(packageUtils.getPackageDependencies(null)).toEqual([]);
+            expect(packageUtils.getPackageDependencies(invalidDepDefinition)).toEqual([]);
         });
 
     });
 
-    describe('.getPackageManifest', function () {
+    describe('.getPackageManifest', () => {
 
-        beforeEach(function () {
+        beforeEach(() => {
             spyOn(packageUtils, 'readJSON');
         });
 
-        it('throws with invalid arguments', function () {
-            expect(function () {
+        it('throws with invalid arguments', () => {
+            expect(() => {
                 packageUtils.getPackageManifest(null);
             }).toThrow();
         });
 
-        it('throws if the manifest does not have a name', function () {
-            var emptyManifest = {};
+        it('throws if the manifest does not have a name', () => {
+            let emptyManifest = {};
             packageUtils.readJSON.and.returnValue(emptyManifest);
-            expect(function () {
+            expect(() => {
                 packageUtils.getPackageManifest(directory)
             }).toThrow();
         });
 
-        it('retrieves the directory\'s manifest', function () {
+        it('retrieves the directory\'s manifest', () => {
             expect(packageUtils.getPackageManifest(directory)).toBeNull();
 
-            var validManifest = {name: 'pack1'};
+            let validManifest = {name: 'pack1'};
             packageUtils.readJSON.and.returnValue(validManifest);
             expect(packageUtils.getPackageManifest(directory)).toBe(validManifest);
         });
 
     });
 
-    describe('.isIgnored', function () {
+    describe('.isIgnored', () => {
 
-        it('checks if a package is ignored by its name', function () {
+        it('checks if a package is ignored by its name', () => {
             expect(packageUtils.isIgnored({name: 'pack1'}, ['pack2', 'pack1'])).toBeTruthy();
             expect(packageUtils.isIgnored({name: 'pack1'}, ['pack2', 'pack2'])).toBeFalsy();
             expect(packageUtils.isIgnored({}, ['pack2', 'pack2'])).toBeFalsy();


### PR DESCRIPTION
 - Remove "private": true from the package.json
 - Allow packageDependencies to be defined as an Array in the package.json configuration of LabShare packages

Details on scoping:
https://docs.npmjs.com/misc/scope