### PR TITLE
Breaking change: new Socket API system

### DIFF
--- a/docs/socket-apis.md
+++ b/docs/socket-apis.md
@@ -1,23 +1,38 @@
-## Socket.io APIs
+## Socket APIs
 
 ### How to add new Socket.io connections
 
-Create Node modules inside the 'api' directory of your package that export a
-'onConnect' function. The 'onConnect' function will receive a socket at start
-up as the first argument. You can assign event listeners and handlers to the
-socket as needed.
+To define socket APIs, create CommonJS modules inside the `api` directory of
+your project that export a `sockets` property.  The `sockets` value is an array of socket connection handler objects each
+containing the following properties:
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| event | String | The name of the LabShare package's socket event. |
+| onEvent | Function | The main event handler for the specified event. It receives `socket`, `message`, and `callback` as arguments. |
+| [middleware] | Array or Function | One or more connect-style middleware functions. Each middleware receives an object containing `{socket, socketHandler, message}`, and a callback function. Optional. |
 
 Example:
 
 ```javascript
-// ls-hello/api/hellosocket.js
-exports.onConnect = function (socket) {
-    socket.emit('connected', 'Hi there!');
-    socket.on('some-awesome-event', function (excitingData) {
-        // do something with "excitingData"
-    });
-    // ...
-}
+// ls-email/api/email.js
+exports.sockets [
+    {
+        event: 'send-email',
+        onEvent: (socket, message, callback) => {
+            callback(null, 'Received!');
+        },
+        middleware: [
+            ({socket, socketHandler, message}, next) => {
+                if (~message.address.indexOf('spam')) {
+                    next({message: 'Blocked!'});
+                    return;
+                }
+                next();
+            }
+        ]
+    }
+];
 ```
 
 ### Configuring services for P2P socket communication
@@ -44,5 +59,4 @@ Example:
 
 With the above configuration, `services` will attempt to establish a socket
 connection to `host1` and `host2`. Broadcasting an event
-from your LabShare package would invoke the listeners set up in the `onConnect`
-functions of `host1` and `host2`.
+from your LabShare package would invoke the listeners set up in the socket handlers for `host1` and `host2`.

--- a/lib/api/socket-io-loader.js
+++ b/lib/api/socket-io-loader.js
@@ -2,6 +2,8 @@
 
 const io = require('socket.io'),
     clientio = require('socket.io-client'),
+    validateSocket = require('./validate-socket'),
+    async = require('async'),
     path = require('path'),
     assert = require('assert'),
     {EventEmitter} = require('events'),
@@ -14,23 +16,24 @@ const io = require('socket.io'),
  * @returns {Function|null}
  * @private
  */
-function getConnectHandler(modulePath) {
+function getSockets(modulePath) {
     let socketModule = require(modulePath);
     if (_.isFunction(socketModule)) {
         socketModule = socketModule();
     }
-    return socketModule.onConnect || null;
+    return socketModule.sockets || null;
 }
 
 class SocketIOLoader extends EventEmitter {
 
     /**
-     * @param {Object} server - An instance of a HTTP or HTTPS server
+     * @param {object} server - An instance of a HTTP or HTTPS server
      * @param {object} [options]
      * @param {string} [options.main] - The path to a LabShare package to search for socket IO modules
      * @param {Array.<String>} [options.connections] - A list of URLs to connect to as a server P2P socket client.
      * @param {string|Array} [options.directories] - Additional directories to check for socket.io modules
      * @param {string} [options.pattern] - The glob pattern to use when searching for socket.io modules
+     * @param {object} [options.ioOptions] - Options to pass to the socket.io constructor
      * @constructor
      */
     constructor(server, options = {}) {
@@ -58,8 +61,24 @@ class SocketIOLoader extends EventEmitter {
         });
 
         this._clients = [];
-        this.io = io(server);
+        this._initialized = false;
+        this._sockets = {};  // All the socket definitions from LabShare packages organized by package name
+        this.io = io(server, options.ioOptions);
         this.io.sockets.setMaxListeners(50);  // Increase Node's default limit of 10 listeners
+    }
+
+    /**
+     * @description Caches all the available socket connections defined by LabShare packages
+     * @api
+     */
+    initialize() {
+        this._initialized = true;
+
+        if (this.options.main) {
+            apiUtils.applyToNodeModulesSync(this.options.main, this._cacheSockets.bind(this));
+        }
+
+        _.each(this.options.directories, this._cacheSockets.bind(this));
     }
 
     /**
@@ -67,10 +86,18 @@ class SocketIOLoader extends EventEmitter {
      * @api
      */
     connect() {
+        if (!this._initialized) {
+            this.initialize();
+        }
+
         // Establish client connections for Node process P2P communication
         _.each(this.options.connections, connection => {
             const client = clientio.connect(connection);
-            this._establishSocketConnections(this._connectPackage, client);
+
+            _.each(this._sockets, sockets => {
+                this._onConnection(sockets, client);
+            });
+
             client.on('connect', () => {
                 this.emit('status', `Socket connected to: ${connection}`);
             });
@@ -92,7 +119,13 @@ class SocketIOLoader extends EventEmitter {
 
         // Establish server socket connections and wait until the main socket connection is established before assigning namespaced connections
         this.io.on('connection', () => {
-            this._establishSocketConnections(this._establishNameSpacedConnection);
+            _.each(this._sockets, (sockets, packageName) => {
+                this.io
+                    .of(`/${packageName}`)
+                    .on('connection', socket => {
+                        this._onConnection(sockets, socket);
+                    });
+            });
         });
 
         return this._clients;
@@ -116,79 +149,80 @@ class SocketIOLoader extends EventEmitter {
     }
 
     /**
-     * @param {function} func - A function that will be called with a `packagePath` and any additional arguments passed to _establishSocketConnections()
-     * @param {Array} additionalArgs
-     * @private
+     * @api
+     * @returns All LabShare package socket handlers
      */
-    _establishSocketConnections(func, ...additionalArgs) {
-        let isConnected = {};
-
-        if (this.options.main) {
-            apiUtils.applyToNodeModules(this.options.main, packagePath => {
-                let packageName = apiUtils.getPackageName(apiUtils.getPackageManifest(packagePath));
-
-                // Don't duplicate the event listeners for APIs!
-                if (_.get(isConnected, packageName)) {
-                    return;
-                }
-
-                func.apply(this, [packagePath].concat(additionalArgs));
-
-                isConnected[packageName] = true;
-            }).catch((error) => {
-                this.emit('error', error);
-            });
+    getSockets() {
+        if (!this._initialized) {
+            this.initialize();
         }
 
-        _.each(this.options.directories, (packagePath) => {
-            let packageName = apiUtils.getPackageName(apiUtils.getPackageManifest(packagePath));
+        return this._sockets;
+    }
 
-            // Don't duplicate the event listeners for APIs!
-            if (_.get(isConnected, packageName)) {
+    _cacheSockets(packagePath) {
+        let packageName = apiUtils.getPackageName(apiUtils.getPackageManifest(packagePath));
+
+        if (this._sockets[packageName]) {
+            return;
+        }
+
+        this._sockets[packageName] = [];
+
+        let socketIOModules = apiUtils.getMatchingFilesSync(packagePath, this.options.pattern);
+
+        // Collect all the Node modules containing socket definitions
+        _.each(socketIOModules, modulePath => {
+            let sockets = getSockets(modulePath);
+
+            if (_.isEmpty(sockets)) {
                 return;
             }
 
-            func.apply(this, [packagePath].concat(additionalArgs));
+            // Ensure each socket object has the correct properties before it is cached
+            _.each(sockets, socketDefinition => {
+                let validation = validateSocket(socketDefinition, packageName);
 
-            isConnected[packageName] = true;
+                if (!validation.isValid) {
+                    return Q.reject(new TypeError(validation.message));
+                }
+
+                if (_.isFunction(socketDefinition.middleware)) {
+                    socketDefinition.middleware = [socketDefinition.middleware];
+                }
+
+                this._sockets[packageName].push(socketDefinition);
+            });
         });
     }
 
     /**
      *
-     * @param {string} packagePath
-     * @private
-     */
-    _establishNameSpacedConnection(packagePath) {
-        let packageName = apiUtils.getPackageName(apiUtils.getPackageManifest(packagePath));
-
-        this.io
-            .of('/' + packageName)
-            .on('connection', (socket) => {
-                this._connectPackage(packagePath, socket);
-            });
-    }
-
-    /**
-     *
-     * @param {string} packagePath
+     * @param {array} sockets
      * @param {object} socket
      * @private
      */
-    _connectPackage(packagePath, socket) {
-        let socketIOModules = apiUtils.getMatchingFilesSync(packagePath, this.options.pattern);
+    _onConnection(sockets, socket) {
+        _.each(sockets, socketDefinition => {
+            socket.on(socketDefinition.event, (message, callback) => {
+                if (_.isEmpty(socketDefinition.middleware)) {
+                    socketDefinition.onEvent(socket, message, callback);
+                }
 
-        _.each(socketIOModules, (modulePath) => {
-            let connectHandler = getConnectHandler(modulePath);
-            if (!connectHandler) {
-                return;
-            }
+                let middleware = _.map(socketDefinition.middleware, middleware => {
+                    return next => middleware({socketDefinition, socket, message}, next);
+                });
 
-            if (!_.isFunction(connectHandler)) {
-                this.emit('error', new Error(`The "onConnect" property exposed by module "${modulePath}" must be a function!`));
-            } else {
-                connectHandler(socket);
-            }
+                // Pass the socket connection through each middleware and then finally call the original event handler
+                async.series(middleware, err => {
+                    if (err) {
+                        callback(err);
+                        return;
+                    }
+
+                    socketDefinition.onEvent(socket, message, callback);
+                });
+            });
         });
     }
 }

--- a/lib/api/validate-socket.js
+++ b/lib/api/validate-socket.js
@@ -1,0 +1,54 @@
+'use strict';
+
+const revalidator = require('revalidator'),
+    _ = require('lodash');
+
+/**
+ * @description Checks if the given socket has the required properties
+ * @param {object} socket - An object that defines a socket.io connection event handler
+ * @param {string} packageName - The name of a LabShare package
+ * @returns {{message: string, isValid: boolean}}
+ */
+module.exports = function validateSocket(socket, packageName) {
+    let validation = revalidator.validate(socket, {
+            properties: {
+                event: {
+                    type: 'string',
+                    required: true,
+                    allowEmpty: false
+                },
+                onEvent: {
+                    required: true,
+                    allowEmpty: false,
+                    conform(onEvent) {
+                        return _.isFunction(onEvent);
+                    },
+                    messages: {
+                        conform: 'onEvent must be a function'
+                    },
+                },
+                middleware: {
+                    conform(middleware) {
+                        return _.isFunction(middleware) || _.isArray(middleware);
+                    },
+                    messages: {
+                        conform: 'middleware must be a function or an array of functions'
+                    },
+                    required: false,
+                    allowEmpty: true
+                }
+            }
+        }
+    );
+
+    let message = `Invalid socket definition "${JSON.stringify(socket)}" from LabShare package "${packageName}": `;
+
+    validation.errors.forEach((error, index) => {
+        message += `${error.property} ${error.message}${(index < validation.errors.length - 1) ? ', ' : '. '}`;
+    });
+
+    return {
+        message,
+        isValid: validation.valid
+    };
+};

--- a/lib/services.js
+++ b/lib/services.js
@@ -45,7 +45,7 @@ class Services {
             directories: [],
             morgan: {
                 enable: true,
-                format: this._isProduction ? 'dev' : 'combined',
+                format: this._isProduction ? 'combined' : 'dev',
                 options: {
                     // Workaround to add fluentD integration with the morgan logging library
                     stream: _.get(this.logger, 'stream.write')
@@ -106,6 +106,8 @@ class Services {
         }
 
         this._app.use(require('express-session')(this._options.security.sessionOptions));
+
+        this._socketLoader.initialize();
         this._apiLoader.initialize();
     }
 
@@ -125,6 +127,7 @@ class Services {
 
         func({
             services: this._apiLoader.services,
+            sockets: this._socketLoader.getSockets(),
             app: this._app,
             io: this.io()
         });

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@ls/services",
   "namespace": "services",
   "main": "./",
-  "version": "v0.16.0119",
+  "version": "v0.16.0123",
   "description": "LabShare API service manager",
   "contributors": "https://github.com/LabShare/services/graphs/contributors",
   "repository": {
@@ -20,6 +20,7 @@
   "license": "MIT",
   "packageDependencies": {},
   "dependencies": {
+    "async": "^2.1.4",
     "body-parser": "^1.15.1",
     "cookie-parser": "^1.4.3",
     "cors": "^2.7.1",

--- a/test/fixtures/main-package/node_modules/socket-api-package1/api/socket-connection1.js
+++ b/test/fixtures/main-package/node_modules/socket-api-package1/api/socket-connection1.js
@@ -1,9 +1,36 @@
 // Tests the 'Socket IO' API loader
 
-module.exports.onConnect = function (socket) {
-    socket.emit('custom-package-event', 'Hello from socket-api-package1!');
-
-    socket.on('process-something', (data, callback) => {
-       callback(null, 'data');
-    });
-};
+exports.sockets = [
+    {
+        event: 'process-something',
+        onEvent: (socket, message, callback) => {
+            callback(null, 'data');
+        },
+        middleware: [
+            ({socket, socketHandler, message}, next) => {
+                next();
+            }
+        ]
+    },
+    {
+        event: 'send-email',
+        onEvent: (socket, message, callback) => {
+            callback(null, 'Received!');
+        },
+        middleware: [
+            ({socket, socketHandler, message}, next) => {
+                if (~message.address.indexOf('spam')) {
+                    next({message: 'Blocked!'});
+                    return;
+                }
+                next();
+            }
+        ]
+    },
+    {
+        event: 'connected',
+        onEvent: socket => {
+            socket.emit('custom-package-event', 'Hello from socket-api-package1!');
+        }
+    }
+]


### PR DESCRIPTION
Update the SocketIOLoader to load socket connection handlers instead
of simply passing the connected socket to an 'onConnect' function. The
connection handler objects allow the developer of a socket API to specify
the following fields:
 - event: the event name
 - onEvent: the main event handler
 - middleware: an optional array of connect-style middleware that run before the onEvent handler is called

Additional:
 - Update documentation for the new socket API creation system.
 - Update tests