### PR TITLE
Fix module socketHandler and API route mutation

### DIFF
--- a/lib/api/loader.js
+++ b/lib/api/loader.js
@@ -45,7 +45,11 @@ function getRoutes(serviceModule) {
     if (_.isFunction(serviceModule)) {  // support revealing module pattern
         serviceModule = serviceModule();
     }
-    return serviceModule.Routes || serviceModule.routes || [];
+
+    let routes = serviceModule.Routes || serviceModule.routes || [];
+
+    // Ensure modifications ot the route properties do not mutate the original module
+    return _.cloneDeep(routes);
 }
 
 /**

--- a/lib/api/socket-io-loader.js
+++ b/lib/api/socket-io-loader.js
@@ -21,7 +21,7 @@ function getSockets(modulePath) {
     if (_.isFunction(socketModule)) {
         socketModule = socketModule();
     }
-    return socketModule.sockets || null;
+    return socketModule.sockets ? _.cloneDeep(socketModule.sockets) : null;
 }
 
 class SocketIOLoader extends EventEmitter {
@@ -173,25 +173,25 @@ class SocketIOLoader extends EventEmitter {
 
         // Collect all the Node modules containing socket definitions
         _.each(socketIOModules, modulePath => {
-            let sockets = getSockets(modulePath);
+            let socketHandlers = getSockets(modulePath);
 
-            if (_.isEmpty(sockets)) {
+            if (_.isEmpty(socketHandlers)) {
                 return;
             }
 
             // Ensure each socket object has the correct properties before it is cached
-            _.each(sockets, socketDefinition => {
-                let validation = validateSocket(socketDefinition, packageName);
+            _.each(socketHandlers, socketHandler => {
+                let validation = validateSocket(socketHandler, packageName);
 
                 if (!validation.isValid) {
-                    return Q.reject(new TypeError(validation.message));
+                    throw new TypeError(validation.message);
                 }
 
-                if (_.isFunction(socketDefinition.middleware)) {
-                    socketDefinition.middleware = [socketDefinition.middleware];
+                if (_.isFunction(socketHandler.middleware)) {
+                    socketHandler.middleware = [socketHandler.middleware];
                 }
 
-                this._sockets[packageName].push(socketDefinition);
+                this._sockets[packageName].push(socketHandler);
             });
         });
     }
@@ -203,14 +203,14 @@ class SocketIOLoader extends EventEmitter {
      * @private
      */
     _onConnection(sockets, socket) {
-        _.each(sockets, socketDefinition => {
-            socket.on(socketDefinition.event, (message, callback) => {
-                if (_.isEmpty(socketDefinition.middleware)) {
-                    socketDefinition.onEvent(socket, message, callback);
+        _.each(sockets, socketHandler => {
+            socket.on(socketHandler.event, (message, callback) => {
+                if (_.isEmpty(socketHandler.middleware)) {
+                    socketHandler.onEvent(socket, message, callback);
                 }
 
-                let middleware = _.map(socketDefinition.middleware, middleware => {
-                    return next => middleware({socketDefinition, socket, message}, next);
+                let middleware = _.map(socketHandler.middleware, middleware => {
+                    return next => middleware({socketHandler, socket, message}, next);
                 });
 
                 // Pass the socket connection through each middleware and then finally call the original event handler
@@ -220,7 +220,7 @@ class SocketIOLoader extends EventEmitter {
                         return;
                     }
 
-                    socketDefinition.onEvent(socket, message, callback);
+                    socketHandler.onEvent(socket, message, callback);
                 });
             });
         });


### PR DESCRIPTION
The original modules containing sockets or API routes were being mutated
when LabShare Service plugins attached new middleware.