### PR TITLE
Expose Socket.IO instance in Socket middleware as 'io'

### DIFF
--- a/lib/api/socket-io-loader.js
+++ b/lib/api/socket-io-loader.js
@@ -198,19 +198,23 @@ class SocketIOLoader extends EventEmitter {
 
     /**
      *
-     * @param {array} sockets
+     * @param {array} socketHandlers
      * @param {object} socket
      * @private
      */
-    _onConnection(sockets, socket) {
-        _.each(sockets, socketHandler => {
+    _onConnection(socketHandlers, socket) {
+        _.each(socketHandlers, socketHandler => {
             socket.on(socketHandler.event, (message, callback) => {
+                if (_.isFunction(message)) {
+                    callback = message;
+                }
+
                 if (_.isEmpty(socketHandler.middleware)) {
                     socketHandler.onEvent(socket, message, callback);
                 }
 
                 let middleware = _.map(socketHandler.middleware, middleware => {
-                    return next => middleware({socketHandler, socket, message}, next);
+                    return next => middleware({socketHandler, socket, message, io: this.io}, next);
                 });
 
                 // Pass the socket connection through each middleware and then finally call the original event handler


### PR DESCRIPTION
 - Ensure 'message' parameter in socket 'onEvent' handler functions is optional