### PR TITLE
Update Socket 'onEvent' API: inject IO instance and use object destructuring

### DIFF
--- a/lib/api/socket-io-loader.js
+++ b/lib/api/socket-io-loader.js
@@ -202,13 +202,15 @@ class SocketIOLoader extends EventEmitter {
                     message = null;
                 }
 
+                let eventOptions = {socket, message, io: this.io, socketHandler};
+
                 if (_.isEmpty(socketHandler.middleware)) {
-                    socketHandler.onEvent(socket, message, callback);
+                    socketHandler.onEvent(eventOptions, callback);
                     return;
                 }
 
                 let middleware = _.map(socketHandler.middleware, middleware => {
-                    return next => middleware({socketHandler, socket, message, io: this.io}, next);
+                    return next => middleware(eventOptions, next);
                 });
 
                 // Pass the socket connection through each middleware and then finally call the original event handler
@@ -218,7 +220,7 @@ class SocketIOLoader extends EventEmitter {
                         return;
                     }
 
-                    socketHandler.onEvent(socket, message, callback);
+                    socketHandler.onEvent(eventOptions, callback);
                 });
             });
         });

--- a/test/fixtures/main-package/node_modules/socket-api-package1/api/socket-connection.js
+++ b/test/fixtures/main-package/node_modules/socket-api-package1/api/socket-connection.js
@@ -3,7 +3,7 @@
 exports.sockets = [
     {
         event: 'process-something',
-        onEvent: (socket, message, callback) => {
+        onEvent: ({socket, message}, callback) => {
             callback(null, 'data');
         },
         middleware: [
@@ -14,7 +14,7 @@ exports.sockets = [
     },
     {
         event: 'send-email',
-        onEvent: (socket, message, callback) => {
+        onEvent: ({socket, message}, callback) => {
             callback(null, 'Received!');
         },
         middleware: [
@@ -31,7 +31,7 @@ exports.sockets = [
     },
     {
         event: 'connected',
-        onEvent: socket => {
+        onEvent: ({socket}) => {
             socket.emit('custom-package-event', 'Hello from socket-api-package1!');
         }
     }


### PR DESCRIPTION
 - Instead of passing the 'onEvent' function the 'socket', 'message' and 'callback', pass
it an object containing the 'message', 'io' instance, 'socket', 'socketHandler', and a 'callback' as the 2nd argument.