### PR TITLE
AUTH-239 #qa/testing Remove cors middleware

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -84,21 +84,6 @@ Example:
 
 You can also pass a constructor in the `store` option from https://github.com/expressjs/session#compatible-session-stores.
 
-#### corsOptions
-
-The `corsOptions` object corresponds to the options used by [cors](https://www.npmjs.com/package/cors#configuration-options).
-
-Default:
-```json
-"security": {
-    "corsOptions": {
-        "origin": "*",
-        "methods": "GET,HEAD,PUT,PATCH,POST,DELETE",
-        "preflightContinue": false
-    }
-}
-```
-
 #### Additional
 
 The `security` object can also contain directives for several other security libraries. For a complete list, visit [helmet](https://www.npmjs.com/package/helmet#how-it-works) and [helmet docs](https://helmetjs.github.io/docs/).

--- a/lib/services.js
+++ b/lib/services.js
@@ -6,7 +6,6 @@
 
 const _ = require('lodash'),
     express = require('express'),
-    cors = require('cors'),
     crypto = require('crypto'),
     cookieParser = require('cookie-parser'),
     bodyParser = require('body-parser'),
@@ -28,7 +27,7 @@ class Services {
      * @description Sets up HTTP and Socket APIs using routes, socket connections, and configuration functions defined by LabShare API packages
      * @param {Object} [options]
      * @param {Object} [options.listen] - Port/host configuration options
-     * @param {Object} [options.security] - Options to pass to the helmet, cors, and express-session libraries
+     * @param {Object} [options.security] - Options to pass to the helmet, and express-session libraries
      * @param {Boolean} [options.loadServices] - Do not load APIs if false. Default: true
      * @param {String} [options.main] - A relative or absolute path to a directory containing a LabShare package. Default: process.cwd()
      * @param {String} [options.pattern] - The pattern used to match LabShare API modules
@@ -84,11 +83,6 @@ class Services {
                 hpkp: false,
                 referrerPolicy: {
                     policy: 'no-referrer'
-                },
-                corsOptions: {
-                    origin: '*',
-                    methods: 'GET,HEAD,PUT,PATCH,POST,DELETE',
-                    preflightContinue: false
                 }
             }
         });
@@ -109,7 +103,6 @@ class Services {
         this._app.use(helmet(this._options.security));
         this._app.use(bodyParser.json());
         this._app.use(bodyParser.urlencoded({extended: true}));
-        this._app.use(cors(this._options.security.corsOptions));
 
         if (this._options.morgan.enable) {
             this._app.use(morgan(this._options.morgan.format, this._options.morgan.options));

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@labshare/services",
   "namespace": "services",
   "main": "./",
-  "version": "v0.17.0822",
+  "version": "v0.17.0824",
   "description": "LabShare API service manager",
   "contributors": "https://github.com/LabShare/services/graphs/contributors",
   "repository": {
@@ -23,7 +23,6 @@
     "body-parser": "^1.15.1",
     "connect-redis": "^3.2.0",
     "cookie-parser": "^1.4.3",
-    "cors": "^2.7.1",
     "dotenv": "^4.0.0",
     "express": "^4.13.4",
     "express-session": "^1.14.1",

--- a/sample-config.json
+++ b/sample-config.json
@@ -18,11 +18,6 @@
         "store": null,
         "storeOptions": {}
       },
-      "corsOptions": {
-        "origin": "*",
-        "methods": "GET,HEAD,PUT,PATCH,POST,DELETE",
-        "preflightContinue": false
-      },
       "contentSecurityPolicy": false,
       "hpkp": false,
       "referrerPolicy": {

--- a/test/lib/unit/lib/services_spec.js
+++ b/test/lib/unit/lib/services_spec.js
@@ -73,7 +73,6 @@ describe('Services', () => {
             .then(data => {
                 // Check default security headers
                 expect(data.headers['x-powered-by']).toBeUndefined();
-                expect(data.headers['access-control-allow-origin']).toBe('*');
                 expect(data.headers['x-dns-prefetch-control']).toBe('off');
                 expect(data.headers['referrer-policy']).toBe('no-referrer');
                 expect(data.headers['x-xss-protection']).toBe('1; mode=block');


### PR DESCRIPTION
 - Attaching the cors middleware at the root level does not allow sufficient
route-based customization of the CORS headers.