### PR TITLE
SHELL-1189 #done Rename build version environment variable

### DIFF
--- a/api/api-config.js
+++ b/api/api-config.js
@@ -11,7 +11,7 @@ function addVersionRoutes(versionDependencies) {
 
     function returnVersion(req, res) {
         res.json({
-            buildVersion: process.env.BUILD_VERSION || 'unknown',
+            buildVersion: process.env.LABSHARE_BUILD_VERSION || 'unknown',
             versions: versionDependencies
         });
     }

--- a/docs/env-vars.md
+++ b/docs/env-vars.md
@@ -4,7 +4,7 @@ LabShare Services can use the following environment variables:
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| BUILD_VERSION | String | Can be used to display a build or deployment version when accessing the `/versions` API route. Optional. |
+| LABSHARE_BUILD_VERSION | String | Can be used to display a build or deployment version when accessing the `/versions` API route. Optional. |
 | PORT | Number | The port used to run the server. It overrides the `config.json` value set for `services.listen.port`. Optional. |
 
 ### Defining environment variables using a .env file

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@labshare/services",
   "namespace": "services",
   "main": "./",
-  "version": "v0.17.0824",
+  "version": "v0.17.0912",
   "description": "LabShare API service manager",
   "contributors": "https://github.com/LabShare/services/graphs/contributors",
   "repository": {


### PR DESCRIPTION
Resolves a name conflict with CI deployments.