### PR TITLE
SHELL-1245 #qa/testing Allow /endpoint and /version APIs to be access…

### DIFF
--- a/.nsprc
+++ b/.nsprc
@@ -1,0 +1,3 @@
+{
+  "exceptions": ["https://nodesecurity.io/advisories/534"]
+}

--- a/api/api-config.js
+++ b/api/api-config.js
@@ -1,6 +1,7 @@
 'use strict';
 
-const _ = require('lodash');
+const _ = require('lodash'),
+    cors = require('cors');
 
 /**
  * @param versionDependencies An apps dependencies and information gathered from their package.json
@@ -31,13 +32,13 @@ function addVersionRoutes(versionDependencies) {
     return [
         {
             path: `/versions`,
-            httpMethod: 'GET',
-            middleware: [returnVersion]
+            httpMethod: ['OPTIONS', 'GET'],
+            middleware: [cors(), returnVersion]
         },
         {
             path: `/:name/version`,
-            httpMethod: 'GET',
-            middleware: [returnDependencies]
+            httpMethod: ['OPTIONS', 'GET'],
+            middleware: [cors(), returnDependencies]
         }
     ];
 }
@@ -80,13 +81,13 @@ function exposeEndPoints(routes, key) {
     return [
         {
             path: `/${key}/endpoints`,
-            httpMethod: 'GET',
-            middleware: [getReturnEndpoints]
+            httpMethod: ['OPTIONS', 'GET'],
+            middleware: [cors(), getReturnEndpoints]
         },
         {
             path: `/${key}/endpoints`,
-            httpMethod: 'POST',
-            middleware: [postReturnEndpoints]
+            httpMethod: ['OPTIONS', 'POST'],
+            middleware: [cors(), postReturnEndpoints]
         }
     ];
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@labshare/services",
   "namespace": "services",
   "main": "./",
-  "version": "v0.17.0912",
+  "version": "v0.17.1023",
   "description": "LabShare API service manager",
   "contributors": "https://github.com/LabShare/services/graphs/contributors",
   "repository": {
@@ -23,6 +23,7 @@
     "body-parser": "^1.15.1",
     "connect-redis": "^3.2.0",
     "cookie-parser": "^1.4.3",
+    "cors": "^2.8.4",
     "dotenv": "^4.0.0",
     "express": "^4.13.4",
     "express-session": "^1.14.1",


### PR DESCRIPTION
…ible cross-domain

 - Bump version