### PR TITLE
fix(config): remove invalid default audience value

### DIFF
--- a/lib/loopback-proxy-app/application.ts
+++ b/lib/loopback-proxy-app/application.ts
@@ -3,7 +3,7 @@ import {ApplicationConfig} from '@loopback/core';
 import {RestExplorerComponent} from '@loopback/rest-explorer';
 import {RepositoryMixin} from '@loopback/repository';
 import {RestApplication} from '@loopback/rest';
-import * as path from 'path';
+import {join} from 'path';
 import {LabShareSequence} from './sequence';
 import {LegacyLoaderComponent} from './legacy-loader.component';
 import {HealthComponent} from '@labshare/services-health';
@@ -20,11 +20,11 @@ export class LoopbackProxyApplication extends BootMixin(RepositoryMixin(RestAppl
     this.bind(AuthenticationBindings.AUTH_CONFIG).to({
       authUrl: options?.services?.auth?.url || options?.auth?.url || 'https://a.labshare.org/_api',
       tenant: options?.services?.auth?.tenant || options?.services?.auth?.organization || 'ls',
-      audience: options?.services?.auth?.audience || 'ls-api'
+      audience: options?.services?.auth?.audience
     });
 
     // Set up default home page
-    this.static('/', path.join(__dirname, '../public'));
+    this.static('/', join(__dirname, '../public'));
 
     this.component(RestExplorerComponent);
     this.projectRoot = __dirname;

--- a/test/lib/unit/lib/loopback-proxy-app/loopback-proxy-app_spec.ts
+++ b/test/lib/unit/lib/loopback-proxy-app/loopback-proxy-app_spec.ts
@@ -94,7 +94,7 @@ describe('Loopback Proxy App', () => {
         pattern: '{src/api,api}/*.js',
         auth: {
           tenant: 'ls',
-          audience: 'ls-api'
+          audience: 'https://example.com'
         }
       },
       auth: {


### PR DESCRIPTION
Remove "ls-api" default audience value since API audience values must be formatted as a URI.